### PR TITLE
fix: canonical should have href, not content

### DIFF
--- a/SEO.svelte
+++ b/SEO.svelte
@@ -32,7 +32,7 @@
             <meta name="robots" content={index ? "index, follow" : "noindex"}>
         {/if}
         <title>{title}</title>
-        <link rel="canonical" content="{canonical === '' ? $page.url : canonical}">
+        <link rel="canonical" href="{canonical === '' ? $page.url : canonical}">
     {/if}
     {#if description !== ""}
         <meta name="description" content="{description}">


### PR DESCRIPTION
The canonical tag is wrong. The `<link>` tag does not have a `content` attribute, it should be a `href`-attribute for urls.

```svelte
<link rel="canonical" content="{canonical === '' ? $page.url : canonical}">
```

Should be:

```svelte
<link rel="canonical" href="{canonical === '' ? $page.url : canonical}">
```

Sources:
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#href
- https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls#rel-canonical-link-method
