### PR TITLE
doc: config required for prerender and adaptor-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ Also optionally includes functionality for social media preview support
 npm i -D sk-seo
 ```
 
+If you are prerendering, or using adapter-static,  you need to add your base URL in `svelte.config.js`, otherwise `$page.url` will default to `http://sveltekit-prerender`.
+
+```js
+// svelte.config.js
+const config = {
+	kit: {
+		prerender: {
+			origin: 'https://mossberg.dev/' // Replace with your URL.
+		}
+	}
+}
+```
+
 ## Usage
 import the file
 ```svelte

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are prerendering, or using adapter-static,  you need to add your base URL
 const config = {
   kit: {
     prerender: {
-      origin: 'https://mossberg.dev/' // Replace with your URL.
+      origin: 'https://mossberg.dev' // Replace with your URL.
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ If you are prerendering, or using adapter-static,  you need to add your base URL
 ```js
 // svelte.config.js
 const config = {
-	kit: {
-		prerender: {
-			origin: 'https://mossberg.dev/' // Replace with your URL.
-		}
-	}
+  kit: {
+    prerender: {
+      origin: 'https://mossberg.dev/' // Replace with your URL.
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
Added instructions needed for prerendered routes and adaptor-static.

https://kit.svelte.dev/docs/configuration