### PR TITLE
Svelte 4 - (meta duplication fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ All these choices are optional
 | `author`| Represents the author of the page | string | ~ |
 | `socials`| An array of social media links for SchemaOrg | Array | ~ |
 | `name`| The name to be used for SchemaOrg | string | ~ |
+| `type`| The type of the page (website, article, [etc](https://schema.org/docs/full.html)) | string | website |
 
 ## How it works
 The component uses `<svelte:head>` to place meta tags that are filled with sveltekit $page and inputted variables, this means that a lot of the tags are automatically filled for you for each page in your website. An example of this is `og:url`, which requires the url of the current page:

--- a/README.md
+++ b/README.md
@@ -24,16 +24,83 @@ npm i -D sk-seo
 ```
 If you're using @adapter-static, make sure to follow <a href="#prerendering">this</a>
 ## Usage
-import the file
+Add the component to your layout file (eg: `+layout.svelte`).
 ```svelte
+// +layout.svelte
 <script>
   import Seo from 'sk-seo';
 </script>
+
+<Seo />
 ```
-Then place this code anywhere in your svelte file
+This component makes use of `$page.data` **stores**. So we should use some load functions.
+> [!NOTE]
+> These will be automatically picked up by the component and used to fill in the meta tags.
+
+Add a `+layout.js` file alongside your `+layout.svelte` with a load function and return data with the SEO/Meta that you need:
+```js
+// +layout.js
+export const load = async ({ url }) => {
+    // OPTIONAL: You can use url.origin to get the base URL, 
+    // or even url.href to get the full URL.
+    // (For example, to get URLs of images in your /static folder), like this:
+    // imageURL: `${url.origin}/image.jpg`
+    return {
+        title: 'Dahoom - Official',
+        description: 'The official website of Dahoom',
+        keywords: 'dahoom, official, website'
+        // ... and more
+    }
+}
+```
+
+> [!TIP]
+> You can override your `+layout.js` meta from any `+page.js`.
+
+Make sure to add a `+page.js` with a load function to all your pages with the SEO/Meta that you need:
+```js
+// contacts/+page.js
+export const load = async ({ url }) => {
+    // Title, description and keywords set here will replace the title set in +layout.js while visiting /contacts
+    return {
+        title: 'Contacts', 
+        description: 'Where to contact Dahoom AlShaya, whether for business needs or general inquiries',
+        keywords: 'Contact, business, inquiries',
+    }
+}
+```
+
+## DEPRECATED USAGE (Not recommended, duplicates meta tags)
+Put a `<Seo />` tag in each page you want to have SEO for.
+> [!NOTE]
+> This's fine as long as you're making a single-page website (such as, just an homepage). But if you're making a multi-page website, you should use the previous method!
 ```svelte
+// contacts/+page.svelte
+<script>
+  import Seo from 'sk-seo';
+</script>
+
 <Seo 
   title="Contact"
+  description="Where to contact Dahoom AlShaya, whether for business needs or general inquiries"
+  keywords="Contact, business, inquiries"
+/>
+```
+
+> [!CAUTION]
+> Using `<Seo />` on each page will duplicate meta tags. This's why we recommend using the first method (load functions and `<Seo />` only in your +layout.svelte).
+
+### Conflicting stores/load return values
+
+You could even combine stores and manual input if you really have to:
+```svelte
+<script>
+  import Seo from 'sk-seo';
+  import { page } from '$app/stores';
+</script>
+
+<Seo 
+  title={$page.data.customTitle ?? ''}
   description="Where to contact Dahoom AlShaya, whether for business needs or general inquiries"
   keywords="Contact, business, inquiries"
 />
@@ -103,6 +170,9 @@ const config = {
 If you're behind `Cloudflare` and find yourself with duplicated meta tags, then you should disable auto-minify!
 
 `Speed -> Optimization -> Content Optimization -> Auto Minify -> UNCHECK HTML`
+
+> [!WARNING] 
+> Still having duplicated meta? Make sure that you're not using `<Seo />` in each page.
 
 ## License
 [MIT License](https://github.com/TheDahoom/Sveltekit-seo/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you're using @adapter-static, make sure to follow <a href="#prerendering">thi
 ## Usage
 Add the component to your layout file (eg: `+layout.svelte`).
 ```svelte
-// +layout.svelte
+<!-- +layout.svelte -->
 <script>
   import Seo from 'sk-seo';
 </script>
@@ -37,7 +37,8 @@ This component makes use of `$page.data` **stores**. So we should use some load 
 > [!NOTE]
 > These will be automatically picked up by the component and used to fill in the meta tags.
 
-Add a `+layout.js` file alongside your `+layout.svelte` with a load function and return data with the SEO/Meta that you need:
+Add a `+layout.js` file alongside your `+layout.svelte` with a load function and return data with the 
+SEO/Meta that you need:
 ```js
 // +layout.js
 export const load = async ({ url }) => {
@@ -70,12 +71,16 @@ export const load = async ({ url }) => {
 }
 ```
 
+> [!TIP]
+> This also works with `+layout.server.js` and `+page.server.js`.
+
 ## DEPRECATED USAGE (Not recommended, duplicates meta tags)
 Put a `<Seo />` tag in each page you want to have SEO for.
-> [!NOTE]
-> This's fine as long as you're making a single-page website (such as, just an homepage). But if you're making a multi-page website, you should use the previous method!
+> [!WARNING]
+> This's fine as long as you're making a single-page website (such as, just an homepage). But if you're making a 
+> multi-page website, you should use the previous method!
 ```svelte
-// contacts/+page.svelte
+<!-- contacts/+page.svelte -->
 <script>
   import Seo from 'sk-seo';
 </script>
@@ -88,19 +93,22 @@ Put a `<Seo />` tag in each page you want to have SEO for.
 ```
 
 > [!CAUTION]
-> Using `<Seo />` on each page will duplicate meta tags. This's why we recommend using the first method (load functions and `<Seo />` only in your +layout.svelte).
+> Using `<Seo />` on each page will duplicate meta tags. This's why we recommend using the first method 
+> (`load` functions and `<Seo />` only in your `+layout.svelte`).
 
 ### Conflicting stores/load return values
 
-You could even combine stores and manual input if you really have to:
+You could even combine stores (with any name that you want, just make sure to use the same name that you return from 
+your `+layout.js/+page.js` load function) and manual input if you really have to:
 ```svelte
+<!-- +layout.svelte -->
 <script>
   import Seo from 'sk-seo';
   import { page } from '$app/stores';
 </script>
 
 <Seo 
-  title={$page.data.customTitle ?? ''}
+  title={$page.data.customTitle ?? ''} <!-- CUSTOM NAME: title now points to $page.data.customTitle store -->
   description="Where to contact Dahoom AlShaya, whether for business needs or general inquiries"
   keywords="Contact, business, inquiries"
 />

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -2,7 +2,7 @@
     import { page } from "$app/stores";
 
     export let title = $page.data.title ?? "", description = $page.data.description ?? "", keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "", siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
-        author = $page.data.author ?? "", name =$page.data.name ?? "";
+        author = $page.data.author ?? "", name =$page.data.name ?? "", type = $page.data.type ?? "website";
     export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true, openGraph = $page.data.openGraph ?? true;
     export let schemaOrg = $page.data.schemaOrg ?? false, schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
     export let socials = $page.data.socials ?? [], jsonld = $page.data.jsonld ?? {};
@@ -32,7 +32,7 @@
             <meta name="robots" content={index ? "index, follow" : "noindex"}>
         {/if}
         <title>{title}</title>
-        <link rel="canonical" href="{canonical === '' ? $page.url : canonical}">
+        <link rel="canonical" href="{canonical ?? $page.url.href}">
     {/if}
     {#if description !== ""}
         <meta name="description" content="{description}">
@@ -48,8 +48,8 @@
             <meta property="og:site_name" content="{siteName}">
         {/if}
         {#if title !== ""}
-            <meta property="og:url" content="{$page.url}">
-            <meta property="og:type" content="website">
+            <meta property="og:url" content="{$page.url.href}">
+            <meta property="og:type" content="{type}">
             <meta property="og:title" content="{title}">
         {/if}
         {#if description !== ""}
@@ -65,8 +65,8 @@
     {#if twitter}
         {#if title !== ""}
             <meta name="twitter:card" content="summary_large_image">
-            <meta property="twitter:domain" content="{$page.url.host}">
-            <meta property="twitter:url" content="{$page.url}">
+            <meta property="twitter:domain" content="{$page.url.hostname}">
+            <meta property="twitter:url" content="{$page.url.href}">
             <meta name="twitter:title" content="{title}">
         {/if}
         {#if description !== ""}

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -1,14 +1,10 @@
 <script>
-    import {page} from "$app/stores";
+    import { page } from "$app/stores";
 
-    export let title = $page.data.title ?? "", description = $page.data.description ?? "",
-        keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "",
-        siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
-        author = $page.data.author ?? "", name = $page.data.name ?? "", type = $page.data.type ?? "website";
-    export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true,
-        openGraph = $page.data.openGraph ?? true;
-    export let schemaOrg = $page.data.schemaOrg ?? false,
-        schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
+    export let title = $page.data.title ?? "", description = $page.data.description ?? "", keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "", siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
+        author = $page.data.author ?? "", name =$page.data.name ?? "", type = $page.data.type ?? "website";
+    export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true, openGraph = $page.data.openGraph ?? true;
+    export let schemaOrg = $page.data.schemaOrg ?? false, schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
     export let socials = $page.data.socials ?? [], jsonld = $page.data.jsonld ?? {};
 
     $: title = $page.data.title ?? title;
@@ -29,7 +25,7 @@
     $: socials = $page.data.socials ?? socials;
     $: jsonld = $page.data.jsonld ?? jsonld;
 
-    let Ld = {
+    $: Ld = {
         "@context": "https://schema.org",
         "@type": schemaType.length > 1 ? schemaType : schemaType[0],
         "name": name,
@@ -44,7 +40,7 @@
         "sameAs": socials
     };
     Ld = {...Ld, ...jsonld};
-    let LdScript = `<script type="application/ld+json">${JSON.stringify(Ld)}${'<'}/script>`;
+    $: LdScript = `<script type="application/ld+json">${JSON.stringify(Ld)}${'<'}/script>`;
 </script>
 <svelte:head>
     {#if title !== ""}

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -1,11 +1,11 @@
 <script>
     import { page } from "$app/stores";
 
-    export let title = "", description = "", keywords = "", canonical = "", siteName = "", imageURL = "", logo = "",
-        author = "", name = "";
-    export let index = true, twitter = true, openGraph = true;
-    export let schemaOrg = false, schemaType = ['Person', 'Organization'];
-    export let socials = [], jsonld = {};
+    export let title = $page.data.title ?? "", description = $page.data.description ?? "", keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "", siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
+        author = $page.data.author ?? "", name =$page.data.name ?? "";
+    export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true, openGraph = $page.data.openGraph ?? true;
+    export let schemaOrg = $page.data.schemaOrg ?? false, schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
+    export let socials = $page.data.socials ?? [], jsonld = $page.data.jsonld ?? {};
 
     let Ld = {
         "@context": "https://schema.org",
@@ -21,7 +21,7 @@
         },
         "sameAs": socials
     };
-    Ld = { ...Ld, ...jsonld };
+    Ld = {...Ld, ...jsonld};
     let LdScript = `<script type="application/ld+json">${JSON.stringify(Ld)}${'<'}/script>`;
 </script>
 <svelte:head>

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -77,7 +77,7 @@
         {/if}
     {/if}
     <slot/>
-    {#if schemaOrg || socials[0] !== undefined || logo !== "" || name !== ""}
+    {#if schemaOrg && (socials[0] !== undefined || logo !== "" || name !== "")}
         {@html LdScript}
     {/if}
 </svelte:head>

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -1,11 +1,33 @@
 <script>
-    import { page } from "$app/stores";
+    import {page} from "$app/stores";
 
-    export let title = $page.data.title ?? "", description = $page.data.description ?? "", keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "", siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
-        author = $page.data.author ?? "", name =$page.data.name ?? "", type = $page.data.type ?? "website";
-    export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true, openGraph = $page.data.openGraph ?? true;
-    export let schemaOrg = $page.data.schemaOrg ?? false, schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
+    export let title = $page.data.title ?? "", description = $page.data.description ?? "",
+        keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "",
+        siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
+        author = $page.data.author ?? "", name = $page.data.name ?? "", type = $page.data.type ?? "website";
+    export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true,
+        openGraph = $page.data.openGraph ?? true;
+    export let schemaOrg = $page.data.schemaOrg ?? false,
+        schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
     export let socials = $page.data.socials ?? [], jsonld = $page.data.jsonld ?? {};
+
+    $: title = $page.data.title ?? title;
+    $: description = $page.data.description ?? description;
+    $: keywords = $page.data.keywords ?? keywords;
+    $: canonical = $page.data.canonical ?? canonical;
+    $: siteName = $page.data.siteName ?? siteName;
+    $: imageURL = $page.data.imageURL ?? imageURL;
+    $: logo = $page.data.logo ?? logo;
+    $: author = $page.data.author ?? author;
+    $: name = $page.data.name ?? name;
+    $: type = $page.data.type ?? type;
+    $: index = $page.data.index ?? index;
+    $: twitter = $page.data.twitter ?? twitter;
+    $: openGraph = $page.data.openGraph ?? openGraph;
+    $: schemaOrg = $page.data.schemaOrg ?? schemaOrg;
+    $: schemaType = $page.data.schemaType ?? schemaType;
+    $: socials = $page.data.socials ?? socials;
+    $: jsonld = $page.data.jsonld ?? jsonld;
 
     let Ld = {
         "@context": "https://schema.org",

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -32,7 +32,7 @@
             <meta name="robots" content={index ? "index, follow" : "noindex"}>
         {/if}
         <title>{title}</title>
-        <link rel="canonical" href="{canonical ?? $page.url.href}">
+        <link rel="canonical" href="{canonical ? canonical : $page.url.href}">
     {/if}
     {#if description !== ""}
         <meta name="description" content="{description}">

--- a/SEO.svelte.d.ts
+++ b/SEO.svelte.d.ts
@@ -35,6 +35,8 @@ export default class Seo extends SvelteComponent<{
     socials?: string[];
     /** The name to be used for SchemaOrg */
     name?: string;
+    /** The type of the page */
+    type?: string;
 }, {
     [evt: string]: CustomEvent<any>;
 }, {}> {
@@ -61,6 +63,7 @@ declare const __propDef: {
         author?: string;
         socials?: string[];
         name?: string;
+        type?: string;
     };
     events: {
         [evt: string]: CustomEvent<any>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sk-seo",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A lightweight, no depenencies, Sveltekit SEO component to save your time",
   "main": "SEO.svelte",
   "exports": {
@@ -26,5 +26,8 @@
     "url": "git+https://github.com/TheDahoom/Sveltekit-seo.git"
   },
   "author": "Dahoom AlShaya DahoomA@dahoom.com",
-  "license": "MIT"
+  "license": "MIT",
+  "peerDependencies": {
+    "svelte": "<=4.2.19"
+  }
 }


### PR DESCRIPTION
Changelogs:
- New recommended usage of the component with backwards compatibility for previous usage.
- Updated README.
- Added support for page stores.
- Added "type" to props.
- Fixed schemaOrg generating when set to false (disabled).
- Bump to 0.5.0.
- Added peerDependency Svelte <=4.2.19 (this should prevent userswith Svelte 5 from installing the wrong version, they should use version 0.5.0-next instead).
- Internal enhancements.