### PR TITLE
Svelte 5 - (meta duplication fix and Svelte 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ All these choices are optional
 | `author`| Represents the author of the page | string | ~ |
 | `socials`| An array of social media links for SchemaOrg | Array | ~ |
 | `name`| The name to be used for SchemaOrg | string | ~ |
+| `type`| The type of the page (website, article, [etc](https://schema.org/docs/full.html)) | string | website |
 
 ## How it works
 The component uses `<svelte:head>` to place meta tags that are filled with sveltekit $page and inputted variables, this means that a lot of the tags are automatically filled for you for each page in your website. An example of this is `og:url`, which requires the url of the current page:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 > [!DANGER]
-> There's an ongoing issue with Svelte 5 compatibility of this implementation (stores). Values won't update unless you insert props explicitly, like this:
-> ```svelte
-> <script>
->  import { page } from '$app/stores';
-> </script>
-> <Seo title={$page.data.title} description={$page.data.description} keywords={$page.data.keywords} />
-> ```
-> Thus, the previous method may not work either. This requires more testing and development.
+> Svelte 5 support is still pretty much experimental, it requires heavy testing and might not work as expected.
 
 <p align="center">
   <img src="https://github.com/TheDahoom/Sveltekit-seo/assets/105564371/338fd0ad-120f-4b4b-ac00-d56e0b765724" alt="sk-seo logo" />

--- a/README.md
+++ b/README.md
@@ -24,16 +24,83 @@ npm i -D sk-seo
 ```
 If you're using @adapter-static, make sure to follow <a href="#prerendering">this</a>
 ## Usage
-import the file
+Add the component to your layout file (eg: `+layout.svelte`).
 ```svelte
+// +layout.svelte
 <script>
   import Seo from 'sk-seo';
 </script>
+
+<Seo />
 ```
-Then place this code anywhere in your svelte file
+This component makes use of `$page.data` **stores**. So we should use some load functions.
+> [!NOTE]
+> These will be automatically picked up by the component and used to fill in the meta tags.
+
+Add a `+layout.js` file alongside your `+layout.svelte` with a load function and return data with the SEO/Meta that you need:
+```js
+// +layout.js
+export const load = async ({ url }) => {
+    // OPTIONAL: You can use url.origin to get the base URL, 
+    // or even url.href to get the full URL.
+    // (For example, to get URLs of images in your /static folder), like this:
+    // imageURL: `${url.origin}/image.jpg`
+    return {
+        title: 'Dahoom - Official',
+        description: 'The official website of Dahoom',
+        keywords: 'dahoom, official, website'
+        // ... and more
+    }
+}
+```
+
+> [!TIP]
+> You can override your `+layout.js` meta from any `+page.js`.
+
+Make sure to add a `+page.js` with a load function to all your pages with the SEO/Meta that you need:
+```js
+// contacts/+page.js
+export const load = async ({ url }) => {
+    // Title, description and keywords set here will replace the title set in +layout.js while visiting /contacts
+    return {
+        title: 'Contacts', 
+        description: 'Where to contact Dahoom AlShaya, whether for business needs or general inquiries',
+        keywords: 'Contact, business, inquiries',
+    }
+}
+```
+
+## DEPRECATED USAGE (Not recommended, duplicates meta tags)
+Put a `<Seo />` tag in each page you want to have SEO for.
+> [!NOTE]
+> This's fine as long as you're making a single-page website (such as, just an homepage). But if you're making a multi-page website, you should use the previous method!
 ```svelte
+// contacts/+page.svelte
+<script>
+  import Seo from 'sk-seo';
+</script>
+
 <Seo 
   title="Contact"
+  description="Where to contact Dahoom AlShaya, whether for business needs or general inquiries"
+  keywords="Contact, business, inquiries"
+/>
+```
+
+> [!CAUTION]
+> Using `<Seo />` on each page will duplicate meta tags. This's why we recommend using the first method (load functions and `<Seo />` only in your +layout.svelte).
+
+### Conflicting stores/load return values
+
+You could even combine stores and manual input if you really have to:
+```svelte
+<script>
+  import Seo from 'sk-seo';
+  import { page } from '$app/stores';
+</script>
+
+<Seo 
+  title={$page.data.customTitle ?? ''}
   description="Where to contact Dahoom AlShaya, whether for business needs or general inquiries"
   keywords="Contact, business, inquiries"
 />
@@ -103,6 +170,9 @@ const config = {
 If you're behind `Cloudflare` and find yourself with duplicated meta tags, then you should disable auto-minify!
 
 `Speed -> Optimization -> Content Optimization -> Auto Minify -> UNCHECK HTML`
+
+> [!WARNING] 
+> Still having duplicated meta? Make sure that you're not using `<Seo />` in each page.
 
 ## License
 [MIT License](https://github.com/TheDahoom/Sveltekit-seo/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you're using @adapter-static, make sure to follow <a href="#prerendering">thi
 ## Usage
 Add the component to your layout file (eg: `+layout.svelte`).
 ```svelte
-// +layout.svelte
+<!-- +layout.svelte -->
 <script>
   import Seo from 'sk-seo';
 </script>
@@ -37,7 +37,8 @@ This component makes use of `$page.data` **stores**. So we should use some load 
 > [!NOTE]
 > These will be automatically picked up by the component and used to fill in the meta tags.
 
-Add a `+layout.js` file alongside your `+layout.svelte` with a load function and return data with the SEO/Meta that you need:
+Add a `+layout.js` file alongside your `+layout.svelte` with a load function and return data with the 
+SEO/Meta that you need:
 ```js
 // +layout.js
 export const load = async ({ url }) => {
@@ -70,12 +71,16 @@ export const load = async ({ url }) => {
 }
 ```
 
+> [!TIP]
+> This also works with `+layout.server.js` and `+page.server.js`.
+
 ## DEPRECATED USAGE (Not recommended, duplicates meta tags)
 Put a `<Seo />` tag in each page you want to have SEO for.
-> [!NOTE]
-> This's fine as long as you're making a single-page website (such as, just an homepage). But if you're making a multi-page website, you should use the previous method!
+> [!WARNING]
+> This's fine as long as you're making a single-page website (such as, just an homepage). But if you're making a 
+> multi-page website, you should use the previous method!
 ```svelte
-// contacts/+page.svelte
+<!-- contacts/+page.svelte -->
 <script>
   import Seo from 'sk-seo';
 </script>
@@ -88,19 +93,22 @@ Put a `<Seo />` tag in each page you want to have SEO for.
 ```
 
 > [!CAUTION]
-> Using `<Seo />` on each page will duplicate meta tags. This's why we recommend using the first method (load functions and `<Seo />` only in your +layout.svelte).
+> Using `<Seo />` on each page will duplicate meta tags. This's why we recommend using the first method 
+> (`load` functions and `<Seo />` only in your `+layout.svelte`).
 
 ### Conflicting stores/load return values
 
-You could even combine stores and manual input if you really have to:
+You could even combine stores (with any name that you want, just make sure to use the same name that you return from 
+your `+layout.js/+page.js` load function) and manual input if you really have to:
 ```svelte
+<!-- +layout.svelte -->
 <script>
   import Seo from 'sk-seo';
   import { page } from '$app/stores';
 </script>
 
 <Seo 
-  title={$page.data.customTitle ?? ''}
+  title={$page.data.customTitle ?? ''} <!-- CUSTOM NAME: title now points to $page.data.customTitle store -->
   description="Where to contact Dahoom AlShaya, whether for business needs or general inquiries"
   keywords="Contact, business, inquiries"
 />

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> [!DANGER]
+> There's an ongoing issue with Svelte 5 compatibility of this implementation (stores). Values won't update unless you insert props explicitly, like this:
+> ```svelte
+> <script>
+>  import { page } from '$app/stores';
+> </script>
+> <Seo title={$page.data.title} description={$page.data.description} keywords={$page.data.keywords} />
+> ```
+> Thus, the previous method may not work either. This requires more testing and development.
+
 <p align="center">
   <img src="https://github.com/TheDahoom/Sveltekit-seo/assets/105564371/338fd0ad-120f-4b4b-ac00-d56e0b765724" alt="sk-seo logo" />
 </p>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!DANGER]
+> [!CAUTION]
 > Svelte 5 support is still pretty much experimental, it requires heavy testing and might not work as expected.
 
 <p align="center">

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -2,7 +2,7 @@
     import { page } from "$app/stores";
 
     export let title = $page.data.title ?? "", description = $page.data.description ?? "", keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "", siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
-        author = $page.data.author ?? "", name =$page.data.name ?? "";
+        author = $page.data.author ?? "", name =$page.data.name ?? "", type = $page.data.type ?? "website";
     export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true, openGraph = $page.data.openGraph ?? true;
     export let schemaOrg = $page.data.schemaOrg ?? false, schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
     export let socials = $page.data.socials ?? [], jsonld = $page.data.jsonld ?? {};
@@ -32,7 +32,7 @@
             <meta name="robots" content={index ? "index, follow" : "noindex"}>
         {/if}
         <title>{title}</title>
-        <link rel="canonical" href="{canonical === '' ? $page.url : canonical}">
+        <link rel="canonical" href="{canonical ?? $page.url.href}">
     {/if}
     {#if description !== ""}
         <meta name="description" content="{description}">
@@ -48,8 +48,8 @@
             <meta property="og:site_name" content="{siteName}">
         {/if}
         {#if title !== ""}
-            <meta property="og:url" content="{$page.url}">
-            <meta property="og:type" content="website">
+            <meta property="og:url" content="{$page.url.href}">
+            <meta property="og:type" content="{type}">
             <meta property="og:title" content="{title}">
         {/if}
         {#if description !== ""}
@@ -65,8 +65,8 @@
     {#if twitter}
         {#if title !== ""}
             <meta name="twitter:card" content="summary_large_image">
-            <meta property="twitter:domain" content="{$page.url.host}">
-            <meta property="twitter:url" content="{$page.url}">
+            <meta property="twitter:domain" content="{$page.url.hostname}">
+            <meta property="twitter:url" content="{$page.url.href}">
             <meta name="twitter:title" content="{title}">
         {/if}
         {#if description !== ""}

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -1,11 +1,11 @@
 <script>
     import { page } from "$app/stores";
 
-    export let title = "", description = "", keywords = "", canonical = "", siteName = "", imageURL = "", logo = "",
-        author = "", name = "";
-    export let index = true, twitter = true, openGraph = true;
-    export let schemaOrg = false, schemaType = ['Person', 'Organization'];
-    export let socials = [], jsonld = {};
+    export let title = $page.data.title ?? "", description = $page.data.description ?? "", keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "", siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
+        author = $page.data.author ?? "", name =$page.data.name ?? "";
+    export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true, openGraph = $page.data.openGraph ?? true;
+    export let schemaOrg = $page.data.schemaOrg ?? false, schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
+    export let socials = $page.data.socials ?? [], jsonld = $page.data.jsonld ?? {};
 
     let Ld = {
         "@context": "https://schema.org",
@@ -21,7 +21,7 @@
         },
         "sameAs": socials
     };
-    Ld = { ...Ld, ...jsonld };
+    Ld = {...Ld, ...jsonld};
     let LdScript = `<script type="application/ld+json">${JSON.stringify(Ld)}${'<'}/script>`;
 </script>
 <svelte:head>

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -70,7 +70,7 @@
             <meta name="robots" content={index ? "index, follow" : "noindex"}>
         {/if}
         <title>{title}</title>
-        <link rel="canonical" href="{canonical ?? $page.url.href}">
+        <link rel="canonical" href="{canonical ? canonical : $page.url.href}">
     {/if}
     {#if description !== ""}
         <meta name="description" content="{description}">

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -45,77 +45,87 @@
         children
     } = $props();
 
-    let Ld = {
+    // WORKAROUND TO ENSURE REACTIVITY
+    let finalTitle = $derived($page.data.title ?? title), finalDescription = $derived($page.data.description ?? description),
+        finalKeywords = $derived($page.data.keywords ?? keywords), finalCanonical = $derived($page.data.canonical ?? canonical),
+        finalSiteName = $derived($page.data.siteName ?? siteName), finalImageURL = $derived($page.data.imageURL ?? imageURL),
+        finalLogo = $derived($page.data.logo ?? logo), finalType = $derived($page.data.type ?? type),
+        finalAuthor = $derived($page.data.author ?? author), finalName = $derived($page.data.name ?? name);
+    let finalIndex = $derived($page.data.index ?? index), finalTwitter = $derived($page.data.twitter ?? twitter),
+        finalOpenGraph = $derived($page.data.openGraph ?? openGraph), finalSchemaOrg = $derived($page.data.schemaOrg ?? schemaOrg);
+    let finalSchemaType = $derived($page.data.schemaType ?? schemaType), finalSocials = $derived($page.data.socials ?? socials),
+        finalJsonld = $derived($page.data.jsonld ?? jsonld);
+
+    let LdScript = $derived(`<script type="application/ld+json">${JSON.stringify({
         "@context": "https://schema.org",
-        "@type": schemaType.length > 1 ? schemaType : schemaType[0],
-        "name": name,
+        "@type": finalSchemaType.length > 1 ? finalSchemaType : finalSchemaType[0],
+        "name": finalName,
         "url": $page.url.origin,
-        "image": imageURL,
+        "image": finalImageURL,
         "logo": {
             "@type": "ImageObject",
-            "url": logo,
+            "url": finalLogo,
             "width": 48,
             "height": 48
         },
-        "sameAs": socials
-    };
-    Ld = { ...Ld, ...jsonld };
-    let LdScript = `<script type="application/ld+json">${JSON.stringify(Ld)}${'<'}/script>`;
+        "sameAs": finalSocials
+        , ...finalJsonld}
+    )}${'<'}/script>`);
 </script>
 <svelte:head>
-    {#if title !== ""}
-        {#if imageURL}
-            <meta name="robots" content={index ? "index, follow, max-image-preview:large" : "noindex"}>
+    {#if finalTitle !== ""}
+        {#if finalImageURL}
+            <meta name="robots" content={finalIndex ? "index, follow, max-image-preview:large" : "noindex"}>
         {:else}
-            <meta name="robots" content={index ? "index, follow" : "noindex"}>
+            <meta name="robots" content={finalIndex ? "index, follow" : "noindex"}>
         {/if}
-        <title>{title}</title>
-        <link rel="canonical" href="{canonical ? canonical : $page.url.href}">
+        <title>{finalTitle}</title>
+        <link rel="canonical" href="{finalCanonical ? finalCanonical : $page.url.href}">
     {/if}
-    {#if description !== ""}
-        <meta name="description" content="{description}">
+    {#if finalDescription !== ""}
+        <meta name="description" content="{finalDescription}">
     {/if}
-    {#if keywords !== ""}
-        <meta name="keywords" content="{keywords}">
+    {#if finalKeywords !== ""}
+        <meta name="keywords" content="{finalKeywords}">
     {/if}
-    {#if author !== ""}
-        <meta name="author" content="{author}">
+    {#if finalAuthor !== ""}
+        <meta name="author" content="{finalAuthor}">
     {/if}
-    {#if openGraph}
-        {#if siteName !== ""}
-            <meta property="og:site_name" content="{siteName}">
+    {#if finalOpenGraph}
+        {#if finalSiteName !== ""}
+            <meta property="og:site_name" content="{finalSiteName}">
         {/if}
-        {#if title !== ""}
+        {#if finalTitle !== ""}
             <meta property="og:url" content="{$page.url.href}">
-            <meta property="og:type" content="{type}">
-            <meta property="og:title" content="{title}">
+            <meta property="og:type" content="{finalType}">
+            <meta property="og:title" content="{finalTitle}">
         {/if}
-        {#if description !== ""}
-            <meta property="og:description" content="{description}">
+        {#if finalDescription !== ""}
+            <meta property="og:description" content="{finalDescription}">
         {/if}
-        {#if imageURL !== ""}
-            <meta property="og:image" content="{imageURL}">
+        {#if finalImageURL !== ""}
+            <meta property="og:image" content="{finalImageURL}">
         {/if}
-        {#if logo !== ""}
-            <meta property="og:logo" content="{logo}">
+        {#if finalLogo !== ""}
+            <meta property="og:logo" content="{finalLogo}">
         {/if}
     {/if}
-    {#if twitter}
-        {#if title !== ""}
+    {#if finalTwitter}
+        {#if finalTitle !== ""}
             <meta name="twitter:card" content="summary_large_image">
             <meta property="twitter:domain" content="{$page.url.hostname}">
             <meta property="twitter:url" content="{$page.url.href}">
-            <meta name="twitter:title" content="{title}">
+            <meta name="twitter:title" content="{finalTitle}">
         {/if}
-        {#if description !== ""}
-            <meta name="twitter:description" content="{description}">
+        {#if finalDescription !== ""}
+            <meta name="twitter:description" content="{finalDescription}">
         {/if}
-        {#if imageURL !== ""}
-            <meta name="twitter:image" content="{imageURL}">
+        {#if finalImageURL !== ""}
+            <meta name="twitter:image" content="{finalImageURL}">
         {/if}
     {/if}
     {@render children?.()}
-    {#if schemaOrg || socials[0] !== undefined || logo !== "" || name !== ""}
+    {#if finalSchemaOrg && (finalSocials[0] !== undefined || finalLogo !== "" || finalName !== "")}
         {@html LdScript}
     {/if}
 </svelte:head>

--- a/SEO.svelte
+++ b/SEO.svelte
@@ -1,11 +1,49 @@
+<!-- Originally Dahoom Sveltekit-seo -->
 <script>
     import { page } from "$app/stores";
 
-    export let title = $page.data.title ?? "", description = $page.data.description ?? "", keywords = $page.data.keywords ?? "", canonical = $page.data.canonical ?? "", siteName = $page.data.siteName ?? "", imageURL = $page.data.imageURL ?? "", logo = $page.data.logo ?? "",
-        author = $page.data.author ?? "", name =$page.data.name ?? "", type = $page.data.type ?? "website";
-    export let index = $page.data.index ?? true, twitter = $page.data.twitter ?? true, openGraph = $page.data.openGraph ?? true;
-    export let schemaOrg = $page.data.schemaOrg ?? false, schemaType = $page.data.schemaType ?? ['Person', 'Organization'];
-    export let socials = $page.data.socials ?? [], jsonld = $page.data.jsonld ?? {};
+    /**
+     * @type {{
+     * children?: import('svelte').Snippet,
+     * title?: string,
+     * description?: string,
+     * keywords?: string,
+     * canonical?: string,
+     * siteName?: string,
+     * imageURL?: string,
+     * logo?: string,
+     * type?: string,
+     * author?: string,
+     * name?: string,
+     * index?: boolean,
+     * twitter?: boolean,
+     * openGraph?: boolean,
+     * schemaOrg?: boolean,
+     * schemaType?: string[],
+     * socials?: string[],
+     * jsonld?: Record<string, any>
+     * }}
+     * */
+    let {
+        title = $page.data.title ?? "",
+        description = $page.data.description ?? "",
+        keywords = $page.data.keywords ?? "",
+        canonical = $page.data.canonical ?? "",
+        siteName = $page.data.siteName ?? "",
+        imageURL = $page.data.imageURL ?? "",
+        logo = $page.data.logo ?? "",
+        type = $page.data.type ?? "website",
+        author = $page.data.author ?? "",
+        name = $page.data.name ?? "",
+        index = $page.data.index ?? true,
+        twitter = $page.data.twitter ?? true,
+        openGraph = $page.data.openGraph ?? true,
+        schemaOrg = $page.data.schemaOrg ?? false,
+        schemaType = $page.data.schemaType ?? ['Person', 'Organization'],
+        socials = $page.data.socials ?? [],
+        jsonld = $page.data.jsonld ?? {},
+        children
+    } = $props();
 
     let Ld = {
         "@context": "https://schema.org",
@@ -21,7 +59,7 @@
         },
         "sameAs": socials
     };
-    Ld = {...Ld, ...jsonld};
+    Ld = { ...Ld, ...jsonld };
     let LdScript = `<script type="application/ld+json">${JSON.stringify(Ld)}${'<'}/script>`;
 </script>
 <svelte:head>
@@ -76,7 +114,7 @@
             <meta name="twitter:image" content="{imageURL}">
         {/if}
     {/if}
-    <slot/>
+    {@render children?.()}
     {#if schemaOrg || socials[0] !== undefined || logo !== "" || name !== ""}
         {@html LdScript}
     {/if}

--- a/SEO.svelte.d.ts
+++ b/SEO.svelte.d.ts
@@ -35,6 +35,8 @@ export default class Seo extends SvelteComponent<{
     socials?: string[];
     /** The name to be used for SchemaOrg */
     name?: string;
+    /** The type of the page */
+    type?: string;
 }, {
     [evt: string]: CustomEvent<any>;
 }, {}> {
@@ -61,6 +63,7 @@ declare const __propDef: {
         author?: string;
         socials?: string[];
         name?: string;
+        type?: string;
     };
     events: {
         [evt: string]: CustomEvent<any>;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sk-seo",
-  "version": "0.4.3",
+  "version": "0.5.0-next",
   "description": "A lightweight, no depenencies, Sveltekit SEO component to save your time",
   "main": "SEO.svelte",
   "exports": {
@@ -27,7 +27,7 @@
   },
   "author": "Dahoom AlShaya DahoomA@dahoom.com",
   "license": "MIT",
-  "devDependencies": {
-    "svelte": "^5.1.15"
+  "peerDependencies": {
+    "svelte": ">=5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "url": "git+https://github.com/TheDahoom/Sveltekit-seo.git"
   },
   "author": "Dahoom AlShaya DahoomA@dahoom.com",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "svelte": "^5.1.15"
+  }
 }


### PR DESCRIPTION
Changelogs:
- New recommended usage of the component with backwards compatibility of previous one.
- Updated README.
- Added support for page stores.
- Added "type" to props.
- Fixed schemaOrg generating when set to false (disabled).
- Bump to 0.5.0 next.
- Added peerDependency Svelte >=5.0.0 (this should prevent users from using this version with older version, they should use version 0.5.0 instead).
- Internal enhancements.